### PR TITLE
Update README to run the app locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
+DB_CONNECTION=sqlite
+DB_HOST=
+DB_PORT=
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ npm-debug.log
 yarn-error.log
 .env
 .DS_Store
+*.sqlite
+.rnd

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Beetroot Portal
+
 ### Built with Laravel 5.5 + Vue 2.5
-## Installation
+
+## Getting started
+
 ```
-git clone
+git clone https://github.com/nikolaynizruhin/BeetrootApp.git .
 cp .env.example .env
+export $(cat .env | xargs)
 composer install
 npm install
 npm run dev
@@ -12,6 +16,5 @@ php artisan db:seed
 php artisan key:generate
 php artisan storage:link
 php artisan passport:install
-storage/public/avatars/default.png
-storage/public/logos/default.png
+php -S localhost:5000 -t public
 ```


### PR DESCRIPTION
Currently, when one follows the README it fails on the migrate step. This PR changes the default settings to use SQLite as a local database. Also, it adds a command to run a web server locally as the last step.